### PR TITLE
Extract rendering into its own subcomponent

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -51,13 +51,15 @@
 
 ## Documentation
 
-- [ ] Resources
-- [ ] Links
-  - [ ] UrlGenerator
+- [x] Resources
+- [x] Links
+  - [x] UrlGenerator
 - [ ] Representations
-- [ ] Automating resource and collection generation from typed objects
-  - [ ] Hydrators
-  - [ ] Metadata
-  - [ ] ResourceGenerator
-  - [ ] Creating your own metadata classes
-  - [ ] Creating your own resource generator strategies
+  - [x] HalResponseFactory
+  - [ ] Renderers
+- [x] Automating resource and collection generation from typed objects
+  - [x] Hydrators
+  - [x] Metadata
+  - [x] ResourceGenerator
+  - [x] Creating your own metadata classes
+  - [x] Creating your own resource generator strategies

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -42,15 +42,15 @@ class HalResponseFactory
     private $xmlRenderer;
 
     public function __construct(
-        Renderer\JsonRenderer $jsonRenderer = null,
-        Renderer\XmlRenderer $xmlRenderer = null,
         ResponseInterface $responsePrototype = null,
-        callable $streamFactory = null
+        callable $streamFactory = null,
+        Renderer\JsonRenderer $jsonRenderer = null,
+        Renderer\XmlRenderer $xmlRenderer = null
     ) {
-        $this->jsonRenderer = $jsonRenderer ?: new Renderer\JsonRenderer();
-        $this->xmlRenderer = $xmlRenderer ?: new Renderer\XmlRenderer();
         $this->responsePrototype = $responsePrototype ?: new Response();
         $this->streamFactory = $streamFactory ?: Closure::fromCallable([$this, 'generateStream']);
+        $this->jsonRenderer = $jsonRenderer ?: new Renderer\JsonRenderer();
+        $this->xmlRenderer = $xmlRenderer ?: new Renderer\XmlRenderer();
     }
 
     public function createResponse(

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -3,8 +3,6 @@
 namespace Hal;
 
 use Closure;
-use DOMDocument;
-use DOMNode;
 use Negotiation\Negotiator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,14 +31,10 @@ class HalResponseFactory
         'application/*+xml',
     ];
 
-    /**
-     * @var int
-     */
-    private $jsonFlags;
+    /** @var Renderer\JsonRenderer */
+    private $jsonRenderer;
 
-    /**
-     * @var ResponseInterface
-     */
+    /** @var ResponseInterface */
     private $responsePrototype;
 
     /**
@@ -51,12 +45,16 @@ class HalResponseFactory
      */
     private $streamFactory;
 
+    /** @var Renderer\XmlRenderer */
+    private $xmlRenderer;
+
     public function __construct(
         int $jsonFlags = self::DEFAULT_JSON_FLAGS,
         ResponseInterface $responsePrototype = null,
         callable $streamFactory = null
     ) {
-        $this->jsonFlags = $jsonFlags;
+        $this->jsonRenderer = new Renderer\JsonRenderer($jsonFlags);
+        $this->xmlRenderer = new Renderer\XmlRenderer();
         $this->responsePrototype = $responsePrototype ?: new Response();
         $this->streamFactory = $streamFactory ?: Closure::fromCallable([$this, 'generateStream']);
     }
@@ -70,18 +68,23 @@ class HalResponseFactory
         $matchedType = (new Negotiator())->getBest($accept, self::NEGOTIATION_PRIORITIES);
 
         switch (true) {
+            case ($matchedType && strstr($matchedType->getValue(), 'json')):
+                $renderer = $this->jsonRenderer;
+                $mediaType = $mediaType . '+json';
+                break;
             case (! $matchedType):
-                $generator = Closure::fromCallable([$this, 'generateXmlResponse']);
-                break;
-            case (strstr($matchedType->getValue(), 'json')):
-                $generator = Closure::fromCallable([$this, 'generateJsonResponse']);
-                break;
+                // fall-through
             default:
-                $generator = Closure::fromCallable([$this, 'generateXmlResponse']);
+                $renderer = $this->xmlRenderer;
+                $mediaType = $mediaType . '+xml';
                 break;
         }
 
-        return $generator($resource, $mediaType);
+        $body = ($this->streamFactory)();
+        $body->write($renderer->render($resource));
+        return $this->responsePrototype
+            ->withBody($body)
+            ->withHeader('Content-Type', $mediaType);
     }
 
     /**
@@ -105,152 +108,5 @@ class HalResponseFactory
     private function generateStream() : Stream
     {
         return new Stream('php://temp', 'wb+');
-    }
-
-    private function generateJsonResponse(HalResource $resource, string $mediaType) : ResponseInterface
-    {
-        $body = ($this->streamFactory)();
-        $body->write(json_encode($resource, $this->jsonFlags));
-        return $this->responsePrototype
-            ->withBody($body)
-            ->withHeader('Content-Type', $mediaType . '+json');
-    }
-
-    private function generateXmlResponse(HalResource $resource, string $mediaType) : ResponseInterface
-    {
-        $body = ($this->streamFactory)();
-        $body->write($this->createXmlPayload($resource));
-        return $this->responsePrototype
-            ->withBody($body)
-            ->withHeader('Content-Type', $mediaType . '+xml');
-    }
-
-    private function createXmlPayload(HalResource $resource) : string
-    {
-        $dom = new DOMDocument('1.0', 'UTF-8');
-        $dom->formatOutput = true;
-        $dom->appendChild($this->createResourceNode($dom, $resource->toArray()));
-        return trim($dom->saveXML());
-    }
-
-    private function createResourceNode(DOMDocument $doc, array $resource, string $resourceRel = 'self') : DOMNode
-    {
-        // Normalize resource
-        $resource['_links']    = $resource['_links'] ?? [];
-        $resource['_embedded'] = $resource['_embedded'] ?? [];
-
-        $node = $doc->createElement('resource');
-
-        // Self-relational link attributes, if present and singular
-        if (isset($resource['_links']['self']['href'])) {
-            $node->setAttribute('rel', $resourceRel);
-            $node->setAttribute('href', $resource['_links']['self']['href']);
-            foreach ($resource['_links']['self'] as $attribute => $value) {
-                if ($attribute === 'href') {
-                    continue;
-                }
-                $node->setAttribute($attribute, $value);
-            }
-            unset($resource['_links']['self']);
-        }
-
-        foreach ($resource['_links'] as $rel => $linkData) {
-            if ($this->isAssocArray($linkData)) {
-                $node->appendChild($this->createLinkNode($doc, $rel, $linkData));
-                continue;
-            }
-
-            foreach ($linkData as $linkDatum) {
-                $node->appendChild($this->createLinkNode($doc, $rel, $linkDatum));
-            }
-        }
-        unset($resource['_links']);
-
-        foreach ($resource['_embedded'] as $rel => $childData) {
-            if ($this->isAssocArray($childData)) {
-                $node->appendChild($this->createResourceNode($doc, $childData, $rel));
-                continue;
-            }
-
-            foreach ($childData as $childDatum) {
-                $node->appendChild($this->createResourceNode($doc, $childDatum, $rel));
-            }
-        }
-        unset($resource['_embedded']);
-
-        return $this->createNodeTree($doc, $node, $resource);
-    }
-
-    private function createLinkNode(DOMDocument $doc, string $rel, array $data)
-    {
-        $link = $doc->createElement('link');
-        $link->setAttribute('rel', $rel);
-        foreach ($data as $key => $value) {
-            $value = $this->normalizeConstantValue($value);
-            $link->setAttribute($key, $value);
-        }
-        return $link;
-    }
-
-    /**
-     * Convert true, false, and null to appropriate strings.
-     *
-     * In all other cases, return the value as-is.
-     *
-     * @param mixed $value
-     * @return string|mixed
-     */
-    private function normalizeConstantValue($value)
-    {
-        $value = $value === true ? 'true' : $value;
-        $value = $value === false ? 'false' : $value;
-        $value = $value === null ? '' : $value;
-        return $value;
-    }
-
-    private function isAssocArray(array $value) : bool
-    {
-        return array_values($value) !== $value;
-    }
-
-    /**
-     * @return DOMNode|DOMNode[]
-     */
-    private function createResourceElement(DOMDocument $doc, string $name, $data)
-    {
-        if (is_scalar($data)) {
-            $data = $this->normalizeConstantValue($data);
-            return $doc->createElement($name, $data);
-        }
-
-        if (! is_array($data)) {
-            throw Exception\InvalidResourceValueException::fromValue($data);
-        }
-
-        if ($this->isAssocArray($data)) {
-            return $this->createNodeTree($doc, $doc->createElement($name), $data);
-        }
-
-        $elements = [];
-        foreach ($value as $child) {
-            $elements[] = $this->createResourceElement($doc, $name, $child);
-        }
-        return $elements;
-    }
-
-    private function createNodeTree(DOMDocument $doc, DOMNode $node, array $data) : DOMNode
-    {
-        foreach ($data as $key => $value) {
-            $element = $this->createResourceElement($doc, $key, $value);
-            if (! is_array($element)) {
-                $node->appendChild($element);
-                continue;
-            }
-            foreach ($element as $child) {
-                $node->appendChild($child);
-            }
-        }
-
-        return $node;
     }
 }

--- a/src/HalResponseFactory.php
+++ b/src/HalResponseFactory.php
@@ -17,13 +17,6 @@ class HalResponseFactory
      */
     const DEFAULT_CONTENT_TYPE = 'application/hal';
 
-    // @codingStandardsIgnoreStart
-    /**
-     * @var int Default flags to use with json_encode()
-     */
-    const DEFAULT_JSON_FLAGS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
-    // @codingStandardsIgnoreEnd
-
     const NEGOTIATION_PRIORITIES = [
         'application/json',
         'application/*+json',
@@ -49,12 +42,13 @@ class HalResponseFactory
     private $xmlRenderer;
 
     public function __construct(
-        int $jsonFlags = self::DEFAULT_JSON_FLAGS,
+        Renderer\JsonRenderer $jsonRenderer = null,
+        Renderer\XmlRenderer $xmlRenderer = null,
         ResponseInterface $responsePrototype = null,
         callable $streamFactory = null
     ) {
-        $this->jsonRenderer = new Renderer\JsonRenderer($jsonFlags);
-        $this->xmlRenderer = new Renderer\XmlRenderer();
+        $this->jsonRenderer = $jsonRenderer ?: new Renderer\JsonRenderer();
+        $this->xmlRenderer = $xmlRenderer ?: new Renderer\XmlRenderer();
         $this->responsePrototype = $responsePrototype ?: new Response();
         $this->streamFactory = $streamFactory ?: Closure::fromCallable([$this, 'generateStream']);
     }

--- a/src/HalResponseFactoryFactory.php
+++ b/src/HalResponseFactoryFactory.php
@@ -31,6 +31,9 @@ class HalResponseFactoryFactory
      */
     public function __invoke(ContainerInterface $container) : HalResponseFactory
     {
+        $response = $this->getResponseInstance($container);
+        $streamFactory = $this->getStreamFactory($container);
+
         $jsonRenderer = $container->has(Renderer\JsonRenderer::class)
             ? $container->get(Renderer\JsonRenderer::class)
             : new Renderer\JsonRenderer();
@@ -39,15 +42,11 @@ class HalResponseFactoryFactory
             ? $container->get(Renderer\XmlRenderer::class)
             : new Renderer\XmlRenderer();
 
-        $response = $this->getResponseInstance($container);
-
-        $streamFactory = $this->getStreamFactory($container);
-
         return new HalResponseFactory(
-            $jsonRenderer,
-            $xmlRenderer,
             $response,
-            $streamFactory
+            $streamFactory,
+            $jsonRenderer,
+            $xmlRenderer
         );
     }
 

--- a/src/HalResponseFactoryFactory.php
+++ b/src/HalResponseFactoryFactory.php
@@ -4,33 +4,104 @@ namespace Hal;
 
 use Closure;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 
+/**
+ * Create and return a HalResponseFactory instance.
+ *
+ * Utilizes the following services:
+ *
+ * - `Hal\Renderer\JsonRenderer`, if present; otherwise, creates an instance.
+ * - `Hal\Renderer\XmlRenderer`, if present; otherwise, creates an instance.
+ * - `Psr\Http\Message\ResponseInterface`, if present; otherwise, uses the
+ *   zend-diactoros `Response` class.
+ * - `Psr\Http\Message\StreamInterface`, if present; this service should
+ *   return a callable capable of returning a new stream instance. If none is
+ *   provided, uses a callable returning a zend-diactoros `Stream` class.
+ */
 class HalResponseFactoryFactory
 {
     /**
-     * @throws RuntimeException if zend-diactoros is not installed.
+     * @throws RuntimeException if neither a ResponseInterface service is
+     *     present nor zend-diactoros is installed.
      */
     public function __invoke(ContainerInterface $container) : HalResponseFactory
     {
-        if (! class_exists(Response::class)) {
-            throw new RuntimeException(sprintf(
-                'The %s implementation requires zend-diactoros; either install '
-                . 'zendframework/zend-diactoros, or create an alternate factory.',
-                self::class
-            ));
-        }
+        $jsonRenderer = $container->has(Renderer\JsonRenderer::class)
+            ? $container->get(Renderer\JsonRenderer::class)
+            : new Renderer\JsonRenderer();
+
+        $xmlRenderer = $container->has(Renderer\XmlRenderer::class)
+            ? $container->get(Renderer\XmlRenderer::class)
+            : new Renderer\XmlRenderer();
+
+        $response = $this->getResponseInstance($container);
+
+        $streamFactory = $this->getStreamFactory($container);
 
         return new HalResponseFactory(
-            HalResponseFactory::DEFAULT_JSON_FLAGS,
-            new Response(),
-            Closure::fromCallable([$this, 'generateStream'])
+            $jsonRenderer,
+            $xmlRenderer,
+            $response,
+            $streamFactory
         );
     }
 
-    public function generateStream() : Stream
+    /**
+     * @throws RuntimeException if neither a ResponseInterface service is available
+     *     nor zend-diactoros installed.
+     */
+    private function getResponseInstance(ContainerInterface $container) : ResponseInterface
+    {
+        if ($container->has(ResponseInterface::class)) {
+            return $container->get(ResponseInterface::class);
+        }
+
+        if (class_exists(Response::class)) {
+            return new Response();
+        }
+
+        throw new RuntimeException(sprintf(
+            'The %s implementation requires that you either define a service '
+            . '"%s" or have zend-diactoros installed; either create %s service '
+            . 'or install zendframework/zend-diactoros.',
+            self::class,
+            ResponseInterface::class,
+            ResponseInterface::class
+        ));
+    }
+
+    /**
+     * @throws RuntimeException if neither a StreamInterface service is available
+     *     nor zend-diactoros installed.
+     */
+    private function getStreamFactory(ContainerInterface $container) : callable
+    {
+        if ($container->has(StreamInterface::class)) {
+            return $container->get(StreamInterface::class);
+        }
+
+        if (class_exists(Stream::class)) {
+            return Closure::fromCallable([$this, 'generateStream']);
+        }
+
+        throw new RuntimeException(sprintf(
+            'The %s implementation requires that you either define a service '
+            . '"%s" (which should return a callable capable of returning a %s) '
+            . 'or have zend-diactoros installed; either create %s service '
+            . 'or install zendframework/zend-diactoros.',
+            self::class,
+            StreamInterface::class,
+            StreamInterface::class,
+            StreamInterface::class
+        ));
+    }
+
+    private function generateStream() : Stream
     {
         return new Stream('php://temp', 'wb+');
     }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -6,10 +6,17 @@ use Hal\HalResource;
 
 class JsonRenderer implements Renderer
 {
+    // @codingStandardsIgnoreStart
+    /**
+     * @var int Default flags to use with json_encode()
+     */
+    const DEFAULT_JSON_FLAGS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
+    // @codingStandardsIgnoreEnd
+
     /** @var int */
     private $jsonFlags;
 
-    public function __construct(int $jsonFlags)
+    public function __construct(int $jsonFlags = self::DEFAULT_JSON_FLAGS)
     {
         $this->jsonFlags = $jsonFlags;
     }

--- a/src/Renderer/JsonRenderer.php
+++ b/src/Renderer/JsonRenderer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Hal\Renderer;
+
+use Hal\HalResource;
+
+class JsonRenderer implements Renderer
+{
+    /** @var int */
+    private $jsonFlags;
+
+    public function __construct(int $jsonFlags)
+    {
+        $this->jsonFlags = $jsonFlags;
+    }
+
+    public function render(HalResource $resource) : string
+    {
+        return json_encode($resource, $this->jsonFlags);
+    }
+}

--- a/src/Renderer/Renderer.php
+++ b/src/Renderer/Renderer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hal\Renderer;
+
+use Hal\HalResource;
+
+interface Renderer
+{
+    public function render(HalResource $resource) : string;
+}

--- a/src/Renderer/XmlRenderer.php
+++ b/src/Renderer/XmlRenderer.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Hal\Renderer;
+
+use DOMDocument;
+use DOMNode;
+use Hal\HalResource;
+use Hal\Exception;
+
+class XmlRenderer implements Renderer
+{
+    public function render(HalResource $resource) : string
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+        $dom->appendChild($this->createResourceNode($dom, $resource->toArray()));
+        return trim($dom->saveXML());
+    }
+
+    private function createResourceNode(DOMDocument $doc, array $resource, string $resourceRel = 'self') : DOMNode
+    {
+        // Normalize resource
+        $resource['_links']    = $resource['_links'] ?? [];
+        $resource['_embedded'] = $resource['_embedded'] ?? [];
+
+        $node = $doc->createElement('resource');
+
+        // Self-relational link attributes, if present and singular
+        if (isset($resource['_links']['self']['href'])) {
+            $node->setAttribute('rel', $resourceRel);
+            $node->setAttribute('href', $resource['_links']['self']['href']);
+            foreach ($resource['_links']['self'] as $attribute => $value) {
+                if ($attribute === 'href') {
+                    continue;
+                }
+                $node->setAttribute($attribute, $value);
+            }
+            unset($resource['_links']['self']);
+        }
+
+        foreach ($resource['_links'] as $rel => $linkData) {
+            if ($this->isAssocArray($linkData)) {
+                $node->appendChild($this->createLinkNode($doc, $rel, $linkData));
+                continue;
+            }
+
+            foreach ($linkData as $linkDatum) {
+                $node->appendChild($this->createLinkNode($doc, $rel, $linkDatum));
+            }
+        }
+        unset($resource['_links']);
+
+        foreach ($resource['_embedded'] as $rel => $childData) {
+            if ($this->isAssocArray($childData)) {
+                $node->appendChild($this->createResourceNode($doc, $childData, $rel));
+                continue;
+            }
+
+            foreach ($childData as $childDatum) {
+                $node->appendChild($this->createResourceNode($doc, $childDatum, $rel));
+            }
+        }
+        unset($resource['_embedded']);
+
+        return $this->createNodeTree($doc, $node, $resource);
+    }
+
+    private function createLinkNode(DOMDocument $doc, string $rel, array $data)
+    {
+        $link = $doc->createElement('link');
+        $link->setAttribute('rel', $rel);
+        foreach ($data as $key => $value) {
+            $value = $this->normalizeConstantValue($value);
+            $link->setAttribute($key, $value);
+        }
+        return $link;
+    }
+
+    /**
+     * Convert true, false, and null to appropriate strings.
+     *
+     * In all other cases, return the value as-is.
+     *
+     * @param mixed $value
+     * @return string|mixed
+     */
+    private function normalizeConstantValue($value)
+    {
+        $value = $value === true ? 'true' : $value;
+        $value = $value === false ? 'false' : $value;
+        $value = $value === null ? '' : $value;
+        return $value;
+    }
+
+    private function isAssocArray(array $value) : bool
+    {
+        return array_values($value) !== $value;
+    }
+
+    /**
+     * @return DOMNode|DOMNode[]
+     */
+    private function createResourceElement(DOMDocument $doc, string $name, $data)
+    {
+        if (is_scalar($data)) {
+            $data = $this->normalizeConstantValue($data);
+            return $doc->createElement($name, $data);
+        }
+
+        if (! is_array($data)) {
+            throw Exception\InvalidResourceValueException::fromValue($data);
+        }
+
+        if ($this->isAssocArray($data)) {
+            return $this->createNodeTree($doc, $doc->createElement($name), $data);
+        }
+
+        $elements = [];
+        foreach ($value as $child) {
+            $elements[] = $this->createResourceElement($doc, $name, $child);
+        }
+        return $elements;
+    }
+
+    private function createNodeTree(DOMDocument $doc, DOMNode $node, array $data) : DOMNode
+    {
+        foreach ($data as $key => $value) {
+            $element = $this->createResourceElement($doc, $key, $value);
+            if (! is_array($element)) {
+                $node->appendChild($element);
+                continue;
+            }
+            foreach ($element as $child) {
+                $node->appendChild($child);
+            }
+        }
+
+        return $node;
+    }
+}

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -24,6 +24,8 @@ class HalResponseFactoryTest extends TestCase
         $this->jsonRenderer = $this->prophesize(Renderer\JsonRenderer::class);
         $this->xmlRenderer  = $this->prophesize(Renderer\XmlRenderer::class);
         $this->factory      = new HalResponseFactory(
+            null,
+            null,
             $this->jsonRenderer->reveal(),
             $this->xmlRenderer->reveal()
         );
@@ -159,9 +161,10 @@ class HalResponseFactoryTest extends TestCase
         $this->request->getHeaderLine('Accept')->willReturn('application/json');
 
         $factory = new HalResponseFactory(
+            $prototype->reveal(),
+            null,
             $this->jsonRenderer->reveal(),
-            $this->xmlRenderer->reveal(),
-            $prototype->reveal()
+            $this->xmlRenderer->reveal()
         );
         $response = $factory->createResponse(
             $this->request->reveal(),
@@ -187,10 +190,10 @@ class HalResponseFactoryTest extends TestCase
         };
 
         $factory = new HalResponseFactory(
-            $this->jsonRenderer->reveal(),
-            $this->xmlRenderer->reveal(),
             null,
-            $streamFactory
+            $streamFactory,
+            $this->jsonRenderer->reveal(),
+            $this->xmlRenderer->reveal()
         );
 
         $response = $factory->createResponse(

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -58,12 +58,12 @@ class HalResponseFactoryTest extends TestCase
     public function createExampleJsonPayload(HalResponseFactory $factory = null)
     {
         $factory = $factory ?: $this->factory;
-        $r = new ReflectionProperty($factory, 'jsonFlags');
+        $r = new ReflectionProperty($factory, 'jsonRenderer');
         $r->setAccessible(true);
-        $flags = $r->getValue($factory);
+        $renderer = $r->getValue($factory);
 
         $resource = $this->createExampleResource();
-        return json_encode($resource, $flags);
+        return $renderer->render($resource);
     }
 
     public function createExampleXmlPayload()

--- a/test/HalResponseFactoryTest.php
+++ b/test/HalResponseFactoryTest.php
@@ -5,6 +5,8 @@ namespace HalTest;
 use Hal\HalResource;
 use Hal\HalResponseFactory;
 use Hal\Link;
+use Hal\Renderer;
+use HalTest\Renderer\TestAsset;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
@@ -14,105 +16,33 @@ use ReflectionProperty;
 
 class HalResponseFactoryTest extends TestCase
 {
+    use TestAsset;
+
     public function setUp()
     {
-        $this->request  = $this->prophesize(ServerRequestInterface::class);
-        $this->factory  = new HalResponseFactory();
-    }
-
-    public function createExampleResource()
-    {
-        $resource = new HalResource([
-            'id'      => 'XXXX-YYYY-ZZZZ-ABAB',
-            'example' => true,
-            'foo'     => 'bar',
-        ]);
-        $resource = $resource->withLink(new Link('self', '/example/XXXX-YYYY-ZZZZ-ABAB'));
-        $resource = $resource->withLink(new Link('shift', '/example/XXXX-YYYY-ZZZZ-ABAB/shift'));
-
-        $bar = new HalResource([
-            'id'   => 'BABA-ZZZZ-YYYY-XXXX',
-            'bar'  => true,
-            'some' => 'data',
-        ]);
-        $bar = $bar->withLink(new Link('self', '/bar/BABA-ZZZZ-YYYY-XXXX'));
-        $bar = $bar->withLink(new Link('doc', '/doc/bar'));
-
-        $baz = [];
-        for ($i = 0; $i < 3; $i += 1) {
-            $temp = new HalResource([
-                'id' => 'XXXX-' . $i,
-                'baz' => true,
-            ]);
-            $temp = $temp->withLink(new Link('self', '/baz/XXXX-' . $i));
-            $temp = $temp->withLink(new Link('doc', '/doc/baz'));
-            $baz[] = $temp;
-        }
-
-        $resource = $resource->embed('bar', $bar);
-        $resource = $resource->embed('baz', $baz);
-
-        return $resource;
-    }
-
-    public function createExampleJsonPayload(HalResponseFactory $factory = null)
-    {
-        $factory = $factory ?: $this->factory;
-        $r = new ReflectionProperty($factory, 'jsonRenderer');
-        $r->setAccessible(true);
-        $renderer = $r->getValue($factory);
-
-        $resource = $this->createExampleResource();
-        return $renderer->render($resource);
-    }
-
-    public function createExampleXmlPayload()
-    {
-        // Closing tag causes syntax highlighting to fail everwhere
-        $xml = '<?xml version="1.0" encoding="UTF-8"?' . ">\n";
-        $xml .= <<< 'EOX'
-<resource rel="self" href="/example/XXXX-YYYY-ZZZZ-ABAB">
-  <link rel="shift" href="/example/XXXX-YYYY-ZZZZ-ABAB/shift"/>
-  <resource rel="bar" href="/bar/BABA-ZZZZ-YYYY-XXXX">
-    <link rel="doc" href="/doc/bar"/>
-    <id>BABA-ZZZZ-YYYY-XXXX</id>
-    <bar>true</bar>
-    <some>data</some>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-0">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-0</id>
-    <baz>true</baz>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-1">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-1</id>
-    <baz>true</baz>
-  </resource>
-  <resource rel="baz" href="/baz/XXXX-2">
-    <link rel="doc" href="/doc/baz"/>
-    <id>XXXX-2</id>
-    <baz>true</baz>
-  </resource>
-  <id>XXXX-YYYY-ZZZZ-ABAB</id>
-  <example>true</example>
-  <foo>bar</foo>
-</resource>
-EOX;
-        return $xml;
+        $this->request      = $this->prophesize(ServerRequestInterface::class);
+        $this->jsonRenderer = $this->prophesize(Renderer\JsonRenderer::class);
+        $this->xmlRenderer  = $this->prophesize(Renderer\XmlRenderer::class);
+        $this->factory      = new HalResponseFactory(
+            $this->jsonRenderer->reveal(),
+            $this->xmlRenderer->reveal()
+        );
     }
 
     public function testReturnsJsonResponseIfNoAcceptHeaderPresent()
     {
+        $resource = $this->createExampleResource();
+        $this->jsonRenderer->render($resource)->willReturn('{}');
+        $this->xmlRenderer->render($resource)->shouldNotBeCalled();
         $this->request->getHeaderLine('Accept')->willReturn('');
         $response = $this->factory->createResponse(
             $this->request->reveal(),
-            $this->createExampleResource()
+            $resource
         );
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertContains('application/hal+json', $response->getHeaderLine('Content-Type'));
         $json = (string) $response->getBody();
-        $this->assertEquals($this->createExampleJsonPayload(), $json);
+        $this->assertEquals('{}', $json);
     }
 
     public function jsonAcceptHeaders()
@@ -130,6 +60,8 @@ EOX;
     public function testReturnsJsonResponseIfAcceptHeaderMatchesJson(string $header)
     {
         $resource = $this->createExampleResource();
+        $this->jsonRenderer->render($resource)->willReturn('{}');
+        $this->xmlRenderer->render($resource)->shouldNotBeCalled();
         $this->request->getHeaderLine('Accept')->willReturn($header);
         $response = $this->factory->createResponse(
             $this->request->reveal(),
@@ -138,7 +70,7 @@ EOX;
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertContains('application/hal+json', $response->getHeaderLine('Content-Type'));
         $json = (string) $response->getBody();
-        $this->assertEquals($this->createExampleJsonPayload(), $json);
+        $this->assertEquals('{}', $json);
     }
 
     public function xmlAcceptHeaders()
@@ -157,6 +89,8 @@ EOX;
     public function testReturnsXmlResponseIfAcceptHeaderMatchesXml(string $header)
     {
         $resource = $this->createExampleResource();
+        $this->xmlRenderer->render($resource)->willReturn('<resource/>');
+        $this->jsonRenderer->render($resource)->shouldNotBeCalled();
         $this->request->getHeaderLine('Accept')->willReturn($header);
         $response = $this->factory->createResponse(
             $this->request->reveal(),
@@ -165,15 +99,15 @@ EOX;
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertContains('application/hal+xml', $response->getHeaderLine('Content-Type'));
         $xml = (string) $response->getBody();
-        $this->assertEquals($this->createExampleXmlPayload(), $xml);
+        $this->assertEquals('<resource/>', $xml);
     }
 
     public function customMediaTypes()
     {
         // @codingStandardsIgnoreStart
         return [
-            'json' => ['application/json', 'application/vnd.example', 'createExampleJsonPayload', 'application/vnd.example+json'],
-            'xml'  => ['application/xml',  'application/vnd.example', 'createExampleXmlPayload',  'application/vnd.example+xml'],
+            'json' => ['application/json', 'application/vnd.example', '{}', 'application/vnd.example+json'],
+            'xml'  => ['application/xml',  'application/vnd.example', '<resource/>',  'application/vnd.example+xml'],
         ];
         // @codingStandardsIgnoreEnd
     }
@@ -184,10 +118,22 @@ EOX;
     public function testUsesProvidedMediaTypeInReturnedResponseWithMatchedFormatAppended(
         string $header,
         string $mediaType,
-        string $responseBodyCallback,
+        string $responseBody,
         string $expectedMediaType
     ) {
         $resource = $this->createExampleResource();
+        switch (true) {
+            case (strstr($header, 'json')):
+                $this->jsonRenderer->render($resource)->willReturn($responseBody);
+                $this->xmlRenderer->render($resource)->shouldNotBeCalled();
+                break;
+            case (strstr($header, 'xml')):
+                $this->xmlRenderer->render($resource)->willReturn($responseBody);
+                $this->jsonRenderer->render($resource)->shouldNotBeCalled();
+                // fall-through
+            default:
+                break;
+        }
         $this->request->getHeaderLine('Accept')->willReturn($header);
         $response = $this->factory->createResponse(
             $this->request->reveal(),
@@ -197,64 +143,59 @@ EOX;
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertContains($expectedMediaType, $response->getHeaderLine('Content-Type'));
         $payload = (string) $response->getBody();
-        $this->assertEquals($this->$responseBodyCallback(), $payload);
-    }
-
-    public function testAllowsProvidingFlagsForJsonSerializationToConstructor()
-    {
-        $response = $this->prophesize(ResponseInterface::class);
-        $response->withBody(Argument::type(StreamInterface::class))->will([$response, 'reveal']);
-        $response->withHeader('Content-Type', 'application/hal+json')->will([$response, 'reveal']);
-
-        $this->request->getHeaderLine('Accept')->willReturn('application/json');
-
-        $factory = new HalResponseFactory(
-            HalResponseFactory::DEFAULT_JSON_FLAGS,
-            $response->reveal()
-        );
-
-        $test = $factory->createResponse(
-            $this->request->reveal(),
-            $this->createExampleResource()
-        );
-
-        $this->assertSame($response->reveal(), $test);
+        $this->assertEquals($responseBody, $payload);
     }
 
     public function testAllowsProvidingResponsePrototypeToConstructor()
     {
-        $factory = new HalResponseFactory(0);
+        $resource = $this->createExampleResource();
+
+        $prototype = $this->prophesize(ResponseInterface::class);
+        $prototype->withBody(Argument::type(StreamInterface::class))->will([$prototype, 'reveal']);
+        $prototype->withHeader('Content-Type', 'application/hal+json')->will([$prototype, 'reveal']);
+
+        $this->jsonRenderer->render($resource)->willReturn('{}');
+        $this->xmlRenderer->render($resource)->shouldNotBeCalled();
         $this->request->getHeaderLine('Accept')->willReturn('application/json');
+
+        $factory = new HalResponseFactory(
+            $this->jsonRenderer->reveal(),
+            $this->xmlRenderer->reveal(),
+            $prototype->reveal()
+        );
         $response = $factory->createResponse(
             $this->request->reveal(),
-            $this->createExampleResource()
+            $resource
         );
-        $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertContains('application/hal+json', $response->getHeaderLine('Content-Type'));
-        $payload = (string) $response->getBody();
-        $this->assertEquals($this->createExampleJsonPayload($factory), $payload);
+
+        $this->assertSame($prototype->reveal(), $response);
     }
 
     public function testAllowsProvidingStreamFactoryToConstructor()
     {
+        $resource = $this->createExampleResource();
+
+        $this->jsonRenderer->render($resource)->willReturn('{}');
+        $this->xmlRenderer->render($resource)->shouldNotBeCalled();
+        $this->request->getHeaderLine('Accept')->willReturn('application/json');
+
         $stream = $this->prophesize(StreamInterface::class);
-        $stream->write($this->createExampleJsonPayload())->shouldBeCalled();
+        $stream->write('{}')->shouldBeCalled();
 
         $streamFactory = function () use ($stream) {
             return $stream->reveal();
         };
 
-        $this->request->getHeaderLine('Accept')->willReturn('application/json');
-
         $factory = new HalResponseFactory(
-            HalResponseFactory::DEFAULT_JSON_FLAGS,
+            $this->jsonRenderer->reveal(),
+            $this->xmlRenderer->reveal(),
             null,
             $streamFactory
         );
 
         $response = $factory->createResponse(
             $this->request->reveal(),
-            $this->createExampleResource()
+            $resource
         );
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertContains('application/hal+json', $response->getHeaderLine('Content-Type'));

--- a/test/Renderer/JsonRendererTest.php
+++ b/test/Renderer/JsonRendererTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace HalTest\Renderer;
+
+use Hal\Renderer\JsonRenderer;
+use PHPUnit\Framework\TestCase;
+
+class JsonRendererTest extends TestCase
+{
+    use TestAsset;
+
+    public function testDelegatesToJsonEncode()
+    {
+        $renderer = new JsonRenderer();
+        $resource = $this->createExampleResource();
+        $expected = json_encode($resource, JsonRenderer::DEFAULT_JSON_FLAGS);
+
+        $this->assertEquals($expected, $renderer->render($resource));
+    }
+
+    public function testRendersUsingJsonFlagsProvidedToConstructor()
+    {
+        $jsonFlags = 0;
+        $renderer  = new JsonRenderer($jsonFlags);
+        $resource  = $this->createExampleResource();
+        $expected  = json_encode($resource, $jsonFlags);
+
+        $this->assertEquals($expected, $renderer->render($resource));
+    }
+}

--- a/test/Renderer/TestAsset.php
+++ b/test/Renderer/TestAsset.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace HalTest\Renderer;
+
+use Hal\HalResource;
+use Hal\Link;
+
+trait TestAsset
+{
+    public function createExampleResource() : HalResource
+    {
+        $resource = new HalResource([
+            'id'      => 'XXXX-YYYY-ZZZZ-ABAB',
+            'example' => true,
+            'foo'     => 'bar',
+        ]);
+        $resource = $resource->withLink(new Link('self', '/example/XXXX-YYYY-ZZZZ-ABAB'));
+        $resource = $resource->withLink(new Link('shift', '/example/XXXX-YYYY-ZZZZ-ABAB/shift'));
+
+        $bar = new HalResource([
+            'id'   => 'BABA-ZZZZ-YYYY-XXXX',
+            'bar'  => true,
+            'some' => 'data',
+        ]);
+        $bar = $bar->withLink(new Link('self', '/bar/BABA-ZZZZ-YYYY-XXXX'));
+        $bar = $bar->withLink(new Link('doc', '/doc/bar'));
+
+        $baz = [];
+        for ($i = 0; $i < 3; $i += 1) {
+            $temp = new HalResource([
+                'id' => 'XXXX-' . $i,
+                'baz' => true,
+            ]);
+            $temp = $temp->withLink(new Link('self', '/baz/XXXX-' . $i));
+            $temp = $temp->withLink(new Link('doc', '/doc/baz'));
+            $baz[] = $temp;
+        }
+
+        $resource = $resource->embed('bar', $bar);
+        $resource = $resource->embed('baz', $baz);
+
+        return $resource;
+    }
+}

--- a/test/Renderer/XmlRendererTest.php
+++ b/test/Renderer/XmlRendererTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace HalTest\Renderer;
+
+use Hal\Renderer\XmlRenderer;
+use PHPUnit\Framework\TestCase;
+
+class XmlRendererTest extends TestCase
+{
+    use TestAsset;
+
+    public function createExampleXmlPayload()
+    {
+        // Closing tag causes syntax highlighting to fail everwhere
+        $xml = '<?xml version="1.0" encoding="UTF-8"?' . ">\n";
+        $xml .= <<< 'EOX'
+<resource rel="self" href="/example/XXXX-YYYY-ZZZZ-ABAB">
+  <link rel="shift" href="/example/XXXX-YYYY-ZZZZ-ABAB/shift"/>
+  <resource rel="bar" href="/bar/BABA-ZZZZ-YYYY-XXXX">
+    <link rel="doc" href="/doc/bar"/>
+    <id>BABA-ZZZZ-YYYY-XXXX</id>
+    <bar>true</bar>
+    <some>data</some>
+  </resource>
+  <resource rel="baz" href="/baz/XXXX-0">
+    <link rel="doc" href="/doc/baz"/>
+    <id>XXXX-0</id>
+    <baz>true</baz>
+  </resource>
+  <resource rel="baz" href="/baz/XXXX-1">
+    <link rel="doc" href="/doc/baz"/>
+    <id>XXXX-1</id>
+    <baz>true</baz>
+  </resource>
+  <resource rel="baz" href="/baz/XXXX-2">
+    <link rel="doc" href="/doc/baz"/>
+    <id>XXXX-2</id>
+    <baz>true</baz>
+  </resource>
+  <id>XXXX-YYYY-ZZZZ-ABAB</id>
+  <example>true</example>
+  <foo>bar</foo>
+</resource>
+EOX;
+        return $xml;
+    }
+
+    public function testRendersExpectedXmlPayload()
+    {
+        $resource = $this->createExampleResource();
+        $expected = $this->createExampleXmlPayload();
+        $renderer = new XmlRenderer();
+
+        $this->assertSame($expected, $renderer->render($resource));
+    }
+}


### PR DESCRIPTION
This patch extracts the rendering capabilities from `HalResourceFactory` into their own classes in a new `Hal\Renderer` subcomponent. They include:

- `Renderer`, an interface for all renderers.
- `JsonRenderer`, for generating JSON representations.
- `XmlRenderer`, for generating XML representations.

The `HalResponseFactory` was updated as follows:

- The PSR-7 arguments to the constructor were pushed to the first arguments.
- The `$jsonFlags` argument was removed.
- Two new optional arguments were introduced for the `JsonRenderer` and `XmlRenderer`; if not provided, default instances are created.