### PR TITLE
Always render links and embedded elements as arrays

### DIFF
--- a/doc/book/hal.md
+++ b/doc/book/hal.md
@@ -77,6 +77,22 @@ properties allowed. As an example:
 At this point, the consumer knows they can access the current resource via the
 "self" relation, and a collection of "books" via the URI "/api/books".
 
+To make client consumption simpler, **this project has chosen to always
+represent links as arrays of link objects** and never as a single link object.
+As such, the above will render as:
+
+```json
+{
+  "_links": {
+    "self": [ { "href": "/api/books/XXXX-YYYY-ZZZZ-AAAA" } ],
+    "books": [ { "href": "/api/books" } ]
+  }
+}
+```
+
+This approach ensures that clients do not need to first test the _type_ returned
+when accessing a link relation; they can instead immediately start iterating.
+
 HAL addresses links in XML with two semantics. First, the `<resource>` element
 can contain linking information, using the "rel" and "href" attributes (and any
 others necessary to describe the link).  Typically, the "self" relational link
@@ -113,21 +129,23 @@ and optionally an `_embedded` member.
 ```json
 {
     "_links": {
-        "self": { "href": "/api/books?page=7" },
-        "first": { "href": "/api/books?page=1" },
-        "prev": { "href": "/api/books?page=6" },
-        "next": { "href": "/api/books?page=8" },
-        "last": { "href": "/api/books?page=17" }
-        "search": {
-            "href": "/api/books?query={searchTerms}",
-            "templated": true
-        }
+        "self": [ { "href": "/api/books?page=7" } ],
+        "first": [ { "href": "/api/books?page=1" } ],
+        "prev": [ { "href": "/api/books?page=6" } ],
+        "next": [ { "href": "/api/books?page=8" } ],
+        "last": [ { "href": "/api/books?page=17" } ]
+        "search": [
+          {
+              "href": "/api/books?query={searchTerms}",
+              "templated": true
+          }
+        ]
     },
     "_embedded": {
         "book": [
             {
                 "_links": {
-                    "self": { "href": "/api/books/1234" }
+                    "self": [ { "href": "/api/books/1234" } ]
                 }
                 "id": 1234,
                 "title": "Hitchhiker's Guide to the Galaxy",
@@ -135,7 +153,7 @@ and optionally an `_embedded` member.
             },
             {
                 "_links": {
-                    "self": { "href": "/api/books/6789" }
+                    "self": [ { "href": "/api/books/6789" } ]
                 }
                 "id": 6789,
                 "title": "Ancillary Justice",
@@ -150,6 +168,12 @@ and optionally an `_embedded` member.
 ```
 
 The above represents a _collection_ of _book_ resources.
+
+To provide consistency to clients, **this project chooses to always embed
+resources as arrays of resources** and never as a single resource object.
+Similar to links, this ensures that clients of your API do not need to test the
+_type_ of an embedded resource prior to processing; they can simply start
+iterating or using array operations.
 
 To address XML, the specification uses the `<resource>` element to embed
 additional resources. Resources of the same type use the same `rel` attribute.

--- a/doc/book/intro.md
+++ b/doc/book/intro.md
@@ -233,10 +233,10 @@ use Hal\HalResponseFactory;
 use Hal\ResourceGenerator;
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
-use Psr\Http\ServerRequestInterface;
+use Psr\Http\Messager\ServerRequestInterface;
 use RuntimeException;
 
-class BookAction
+class BookAction implements MiddlewareInterface
 {
     /** @var Repository */
     private $repository;
@@ -257,7 +257,7 @@ class BookAction
         $this->responseFactory = $responseFactory;
     }
 
-    public function __invoke(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         $id = $request->getAttribute('id', false);
         if (! $id) {
@@ -285,7 +285,7 @@ The generated payload might look like the following:
 ```json
 {
     "_links": {
-        "self": { "href": "/api/books/1234" }
+        "self": [ { "href": "/api/books/1234" } ]
     },
     "id": 1234,
     "title": "Hitchhiker's Guide to the Galaxy",
@@ -308,10 +308,10 @@ use Hal\HalResponseFactory;
 use Hal\ResourceGenerator;
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
-use Psr\Http\ServerRequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
-class BooksAction
+class BooksAction implements MiddlewareInterface
 {
     /** @var Repository */
     private $repository;
@@ -332,7 +332,7 @@ class BooksAction
         $this->responseFactory = $responseFactory;
     }
 
-    public function __invoke(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         $page = $request->getQueryParams()['page'] ?? 1;
 
@@ -358,21 +358,23 @@ class, we might get back something like the following:
 ```json
 {
     "_links": {
-        "self": { "href": "/api/books?page=7" },
-        "first": { "href": "/api/books?page=1" },
-        "prev": { "href": "/api/books?page=6" },
-        "next": { "href": "/api/books?page=8" },
-        "last": { "href": "/api/books?page=17" }
-        "search": {
-            "href": "/api/books?query={searchTerms}",
-            "templated": true
-        }
+        "self": [ { "href": "/api/books?page=7" } ],
+        "first": [ { "href": "/api/books?page=1" } ],
+        "prev": [ { "href": "/api/books?page=6" } ],
+        "next": [ { "href": "/api/books?page=8" } ],
+        "last": [ { "href": "/api/books?page=17" } ]
+        "search": [
+            {
+                "href": "/api/books?query={searchTerms}",
+                "templated": true
+            }
+        ]
     },
     "_embedded": {
         "book": [
             {
                 "_links": {
-                    "self": { "href": "/api/books/1234" }
+                    "self": [ { "href": "/api/books/1234" } ]
                 }
                 "id": 1234,
                 "title": "Hitchhiker's Guide to the Galaxy",
@@ -380,7 +382,7 @@ class, we might get back something like the following:
             },
             {
                 "_links": {
-                    "self": { "href": "/api/books/6789" }
+                    "self": [ { "href": "/api/books/6789" } ]
                 }
                 "id": 6789,
                 "title": "Ancillary Justice",

--- a/src/HalResource.php
+++ b/src/HalResource.php
@@ -363,7 +363,7 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
 
     private function serializeLinks()
     {
-        $relations = array_reduce($this->links, function (array $byRelation, LinkInterface $link) {
+        return array_reduce($this->links, function (array $byRelation, LinkInterface $link) {
             $representation = array_merge($link->getAttributes(), [
                 'href' => $link->getHref(),
             ]);
@@ -382,12 +382,6 @@ class HalResource implements EvolvableLinkProviderInterface, JsonSerializable
 
             return $byRelation;
         }, []);
-
-        array_walk($relations, function ($links, $key) use (&$relations) {
-            $relations[$key] = 1 === count($links) ? array_shift($links) : $links;
-        });
-
-        return $relations;
     }
 
     private function serializeEmbeddedResources()

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -447,7 +447,7 @@ class HalResourceTest extends TestCase
             'id'  => 12345678,
             '_links' => [
                 'self' => [
-                    'href' => '/api/foo',
+                    ['href' => '/api/foo'],
                 ],
                 'about' => [
                     ['href' => '/doc/about'],
@@ -458,7 +458,7 @@ class HalResourceTest extends TestCase
                 'bar' => [
                     'bar' => 'baz',
                     '_links' => [
-                        'self' => ['href' => '/api/bar'],
+                        'self' => [['href' => '/api/bar']],
                     ],
                 ],
                 'baz' => [
@@ -466,14 +466,14 @@ class HalResourceTest extends TestCase
                         'baz' => 'bat',
                         'id'  => 987654,
                         '_links' => [
-                            'self' => ['href' => '/api/baz/987654'],
+                            'self' => [['href' => '/api/baz/987654']],
                         ],
                     ],
                     [
                         'baz' => 'bat',
                         'id'  => 987653,
                         '_links' => [
-                            'self' => ['href' => '/api/baz/987653'],
+                            'self' => [['href' => '/api/baz/987653']],
                         ],
                     ],
                 ],

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -39,11 +39,11 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource(['foo' => $embedded]);
-        $this->assertEquals(['foo' => $embedded], $resource->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $resource->getElements());
         $representation = $resource->toArray();
         $this->assertArrayHasKey('_embedded', $representation);
         $this->assertArrayHasKey('foo', $representation['_embedded']);
-        $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
+        $this->assertEquals([['foo' => 'bar']], $representation['_embedded']['foo']);
     }
 
     public function testCanConstructWithLinks()
@@ -71,11 +71,11 @@ class HalResourceTest extends TestCase
     {
         $embedded = new HalResource(['foo' => 'bar']);
         $resource = new HalResource([], [], ['foo' => $embedded]);
-        $this->assertEquals(['foo' => $embedded], $resource->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $resource->getElements());
         $representation = $resource->toArray();
         $this->assertArrayHasKey('_embedded', $representation);
         $this->assertArrayHasKey('foo', $representation['_embedded']);
-        $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
+        $this->assertEquals([['foo' => 'bar']], $representation['_embedded']['foo']);
     }
 
     public function testNonResourceOrCollectionItemsRaiseExceptionDuringConstruction()
@@ -194,11 +194,11 @@ class HalResourceTest extends TestCase
         $new = $resource->withElement('foo', $embedded);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
-        $this->assertEquals(['foo' => $embedded], $new->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $new->getElements());
         $representation = $new->toArray();
         $this->assertArrayHasKey('_embedded', $representation);
         $this->assertArrayHasKey('foo', $representation['_embedded']);
-        $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
+        $this->assertEquals([['foo' => 'bar']], $representation['_embedded']['foo']);
     }
 
     public function testWithElementProxiesToEmbedIfResourceCollectionValueProvided()
@@ -241,7 +241,7 @@ class HalResourceTest extends TestCase
         $new = $resource->embed('foo', $embedded);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
-        $this->assertEquals(['foo' => $embedded], $new->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $new->getElements());
     }
 
     public function testEmbedReturnsNewInstanceWithEmbeddedCollection()
@@ -266,7 +266,7 @@ class HalResourceTest extends TestCase
         $resource = new HalResource(['foo' => $resource1]);
         $new = $resource->embed('foo', $resource2);
         $this->assertNotSame($resource, $new);
-        $this->assertEquals(['foo' => $resource1], $resource->getElements());
+        $this->assertEquals(['foo' => [$resource1]], $resource->getElements());
         $this->assertEquals(['foo' => [$resource1, $resource2]], $new->getElements());
     }
 
@@ -352,11 +352,11 @@ class HalResourceTest extends TestCase
         $new = $resource->withElements(['foo' => $embedded]);
         $this->assertNotSame($resource, $new);
         $this->assertEquals([], $resource->getElements());
-        $this->assertEquals(['foo' => $embedded], $new->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $new->getElements());
         $representation = $new->toArray();
         $this->assertArrayHasKey('_embedded', $representation);
         $this->assertArrayHasKey('foo', $representation['_embedded']);
-        $this->assertEquals(['foo' => 'bar'], $representation['_embedded']['foo']);
+        $this->assertEquals([['foo' => 'bar']], $representation['_embedded']['foo']);
     }
 
     public function testWithElementsOverwritesExistingDataInNewResourceInstance()
@@ -376,7 +376,7 @@ class HalResourceTest extends TestCase
         $new = $resource->withElements(['foo' => $resource2]);
 
         $this->assertNotSame($resource, $new);
-        $this->assertEquals(['foo' => $resource1], $resource->getElements());
+        $this->assertEquals(['foo' => [$resource1]], $resource->getElements());
         $this->assertEquals(['foo' => [$resource1, $resource2]], $new->getElements());
     }
 
@@ -402,7 +402,7 @@ class HalResourceTest extends TestCase
         $resource = new HalResource(['foo' => $embedded]);
         $new = $resource->withoutElement('foo');
         $this->assertNotSame($resource, $new);
-        $this->assertEquals(['foo' => $embedded], $resource->getElements());
+        $this->assertEquals(['foo' => [$embedded]], $resource->getElements());
         $this->assertEquals([], $new->getElements());
     }
 
@@ -456,9 +456,11 @@ class HalResourceTest extends TestCase
             ],
             '_embedded' => [
                 'bar' => [
-                    'bar' => 'baz',
-                    '_links' => [
-                        'self' => [['href' => '/api/bar']],
+                    [
+                        'bar' => 'baz',
+                        '_links' => [
+                            'self' => [['href' => '/api/bar']],
+                        ],
                     ],
                 ],
                 'baz' => [

--- a/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
+++ b/test/ResourceGenerator/ResourceWithNestedInstancesTest.php
@@ -49,6 +49,8 @@ class ResourceWithNestedInstancesTest extends TestCase
         $this->assertInstanceOf(HalResource::class, $resource);
 
         $childResource = $resource->getElement('bar');
+        $this->assertInternalType('array', $childResource);
+        $childResource = array_shift($childResource);
         $this->assertInstanceOf(HalResource::class, $childResource);
         $this->assertEquals($child->id, $childResource->getElement('id'));
         $this->assertEquals($child->message, $childResource->getElement('message'));


### PR DESCRIPTION
Per a [discussion started on Slack](https://zendframework.slackarchive.io/apigility/page-2/ts-1501065209152201), this component should always render both link and embedded relations as _arrays_, versus rendering as a singular object if only one item is available. This simplifies consumers, as they no longer need to test for Array or Object before processing.

This patch will:

- [x] Ensure JSON representations of `_links` relations are always arrays of objects.
- [x] Ensure JSON representations of `_embedded` relations are always arrays of objects.

> ### What about XML?
> 
> The way XML is rendered does not lend itself to making changes. Links are always rendered singularly, so a client has to do work to aggregate them anyways; the same is true for embedded objects, which are simply `<resource>` elements embedded with a `rel` attribute within the parent `<resource>`.
> 
> The only question about rendering XML differently is whether or not the `self` relation, if singular, should be rendered as a `<link>` element, or as attributes of the `<parent>` element; if you have feedback on that, let me know in the comments.