### PR TITLE
Allow forcing relation collections

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -7,6 +7,8 @@ use Psr\Link\EvolvableLinkInterface;
 
 class Link implements EvolvableLinkInterface
 {
+    const AS_COLLECTION = '__FORCE_COLLECTION__';
+
     /**
      * @var array
      */

--- a/test/HalResourceTest.php
+++ b/test/HalResourceTest.php
@@ -498,4 +498,54 @@ class HalResourceTest extends TestCase
     {
         $this->assertEquals($expected, $resource->jsonSerialize());
     }
+
+    public function testAllowsForcingResourceToAggregateAsACollection()
+    {
+        $resource = (new HalResource())
+            ->withLink(new Link('self', '/api/foo'))
+            ->embed(
+                'bar',
+                new HalResource(['bar' => 'baz'], [new Link('self', '/api/bar')]),
+                true
+            );
+
+        $expected = [
+            '_links' => [
+                'self' => [
+                    'href' => '/api/foo',
+                ],
+            ],
+            '_embedded' => [
+                'bar' => [
+                    [
+                        'bar' => 'baz',
+                        '_links' => [
+                            'self' => ['href' => '/api/bar'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $resource->toArray());
+    }
+
+    public function testAllowsForcingLinkToAggregateAsACollection()
+    {
+        $link = new Link('foo', '/api/foo', false, [Link::AS_COLLECTION => true]);
+        $resource = new HalResource(['id' => 'foo'], [$link]);
+
+        $expected = [
+            '_links' => [
+                'foo' => [
+                    [
+                        'href' => '/api/foo',
+                    ],
+                ],
+            ],
+            'id' => 'foo',
+        ];
+
+        $this->assertEquals($expected, $resource->toArray());
+    }
 }


### PR DESCRIPTION
This pull request was requested by @MichaelGooden.

Instead of forcing invariant types per #3, this takes another approach: allowing the developer to force rendering a relation as an array, whether it's a link or an embedded resource.

For links, you will set the attribute `Link::AS_COLLECTION` (evaluating to `__FORCE_COLLECTION__`) to a boolean `true`. During rendering, these values are stripped from the representation, but the flag memoized to ensure that if no other links are present for that relation, the relation is still rendered as an array.

```php
$link = new Link('foo', '/api/foo', false, [Link::AS_COLLECTION => true]);
$resource = $resource->withLink($link);
```

renders as:

```json
"_links": {
  "foo": [
    {"href": "/api/foo"}
  ]
}
```

For embedded resources, you have four options:

- Pass the embedded resource in an array when instantiating the parent resource.
- Pass the embedded resource within an array when calling `withElement()`.
- Pass the embedded resource within an array when calling `embed()`.
- Pass a boolean `true` as the third parameter to `embed()`.

All but the last have worked in previous versions. Examples:

```php
// During instantiation
$resource = new HalResource(['wheels' => [$wheel]]);

// Via withElement():
$resource = $resource->withElement('wheels', [$wheel]);

// Via embed():
$resource = $resource->embed('wheels', [$wheel]);

// Via flag to embed():
$resource = $resource->embed('wheels', $wheel, true);
```

Each might end up with the following representation:

```json
"_embedded": {
  "wheels": [
    {
      "_links": {"self": {"href": "/api/wheel/X"}},
      "id": "X"
    }
  ]
}
```